### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/delete.php
+++ b/action/delete.php
@@ -21,7 +21,7 @@ class action_plugin_fckg_delete extends DokuWiki_Action_Plugin {
     }
 
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'fckg_delete_preprocess');
     }
 

--- a/action/edit.php
+++ b/action/edit.php
@@ -41,7 +41,7 @@ class action_plugin_fckg_edit extends DokuWiki_Action_Plugin {
     }
 
 
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         if(method_exists($this->helper, 'is_outOfScope') &&  $this->helper->is_outOfScope()) return;
         

--- a/action/meta.php
+++ b/action/meta.php
@@ -31,7 +31,7 @@ class action_plugin_fckg_meta extends DokuWiki_Action_Plugin {
   /*
    * Register its handlers with the dokuwiki's event controller
    */
-  function register(&$controller) {            
+  function register(Doku_Event_Handler $controller) {            
             $controller->register_hook( 'TPL_METAHEADER_OUTPUT', 'AFTER', $this, 'loadScript');    
             $controller->register_hook( 'HTML_EDITFORM_INJECTION', 'AFTER', $this, 'preprocess'); 
             $controller->register_hook( 'HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'insertFormElement');            

--- a/action/save.php
+++ b/action/save.php
@@ -18,7 +18,7 @@ class action_plugin_fckg_save extends DokuWiki_Action_Plugin {
 
 
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
   
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'fckg_save_preprocess');
     }

--- a/syntax/dwplugin.php
+++ b/syntax/dwplugin.php
@@ -37,7 +37,7 @@ class syntax_plugin_fckg_dwplugin extends DokuWiki_Syntax_Plugin {
          $this->Lexer->addSpecialPattern('<plugin.*?</plugin>',$mode,'plugin_fckg_dwplugin'); 
        }
 
-    function handle($match, $state, $pos, &$handler){     
+    function handle($match, $state, $pos, Doku_Handler $handler){     
    
    
     $retv = $this->is_stet($match);
@@ -229,7 +229,7 @@ class syntax_plugin_fckg_dwplugin extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
   
         if($mode == 'xhtml'){

--- a/syntax/font.php
+++ b/syntax/font.php
@@ -32,7 +32,7 @@ class syntax_plugin_fckg_font extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
 
         switch ($state) {
@@ -58,7 +58,7 @@ class syntax_plugin_fckg_font extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             list($state, $match) = $data;
 

--- a/syntax/specials.php
+++ b/syntax/specials.php
@@ -62,7 +62,7 @@ class syntax_plugin_fckg_specials extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         $class = "";  
         $xhtml = "";
@@ -85,7 +85,7 @@ class syntax_plugin_fckg_specials extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             list($state, $xhtml) = $data;
             $renderer->doc .=  DOKU_LF . $xhtml . DOKU_LF;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.